### PR TITLE
disable validation to start server without python

### DIFF
--- a/src/main/labview/labview.ts
+++ b/src/main/labview/labview.ts
@@ -58,10 +58,8 @@ export class LabView implements IDisposable {
     this._sessionConfig = options.sessionConfig;
     const sessionConfig = this._sessionConfig;
     this._wsSettings = new WorkspaceSettings(sessionConfig.workingDirectory);
-    this._jlabBaseUrl = `${sessionConfig.url.protocol}//${sessionConfig.url.host}${sessionConfig.url.pathname}`;
-    console.debug(`jlabBaseUrl: ${this._jlabBaseUrl}`);
-
-    /*
+    this._jlabBaseUrl = `${sessionConfig.url.protocol}//${sessionConfig.url.host}${sessionConfig.url.pathname}` || 'http://localhost:8080/';
+    console.log(`      URL  `);    /*
     using a dedicated partition causes PDF rendering issues (object blob in iframe).
     use temporary dedicated partition only for unpersisted remote connections
     */

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -334,17 +334,17 @@ export class Registry implements IRegistry, IDisposable {
   }
 
   validatePythonEnvironmentAtPath(pythonPath: string): boolean {
-    return this._resolveEnvironment(pythonPath) !== undefined;
+    return true;
   }
 
   validateCondaBaseEnvironmentAtPath(envPath: string): boolean {
-    const isWin = process.platform === 'win32';
-    const condaBinPath = path.join(
-      envPath,
-      'condabin',
-      isWin ? 'conda.bat' : 'conda'
-    );
-    return fs.existsSync(condaBinPath) && fs.lstatSync(condaBinPath).isFile();
+    // const isWin = process.platform === 'win32';
+    // const condaBinPath = path.join(
+    //   envPath,
+    //   'condabin',
+    //   isWin ? 'conda.bat' : 'conda'
+    // );
+    return true;
   }
 
   async getEnvironmentInfo(pythonPath: string): Promise<IPythonEnvironment> {

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -91,7 +91,8 @@ function createLaunchScript(
 
   if (isWin) {
       script = `
-        CALL ${launchCmd}`;
+        CALL docker start neurodesktop
+        `;
   } else {
       script = `
       if [[ "$(docker image inspect vnmd/neurodesktop:${tag} --format='exists' 2> /dev/null)" == "exists" ]]; then
@@ -118,6 +119,7 @@ async function checkIfUrlExists(url: URL): Promise<boolean> {
     const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
     const req = requestFn(url, function (r) {
       resolve(r.statusCode >= 200 && r.statusCode < 400);
+      console.debug(`Checking if ${url} exists... ${r.statusCode}`)
     });
     req.on('error', function (err) {
       resolve(false);
@@ -146,7 +148,14 @@ export async function waitUntilServerIsUp(url: URL): Promise<boolean> {
 export class JupyterServer {
   constructor(options: JupyterServer.IOptions, registry: IRegistry) {
     this._options = options;
-    this._info.environment = options.environment;
+    const option:  IPythonEnvironment = {
+      name: 'python',
+      path: 'C:\\',
+      type: IEnvironmentType.Path,
+      versions: {},
+      defaultKernel: 'python3'
+    };
+    this._info.environment = option;
     const workingDir =
       this._options.workingDirectory || userSettings.resolvedWorkingDirectory;
     this._info.workingDirectory = workingDir;
@@ -175,70 +184,72 @@ export class JupyterServer {
       return this._startServer;
     }
     let started = false;
-
+    console.debug("Starting Jupyter server....")
     this._startServer = new Promise<JupyterServer.IInfo>(
       // eslint-disable-next-line no-async-promise-executor
       async (resolve, reject) => {
         const isWin = process.platform === 'win32';
-        const pythonPath = this._info.environment.path;
-        if (!fs.existsSync(pythonPath)) {
-          reject(`Error: Environment not found at: ${pythonPath}`);
-          return;
-        }
+        console.debug("isWin: " + isWin)
+        // const pythonPath = this._info.environment.path;
+        // if (!fs.existsSync(pythonPath)) {
+        //   reject(`Error: Environment not found at: ${pythonPath}`);
+        //   return;
+        // }
         this._info.port = this._options.port || (await getFreePort());
         this._info.token = this._options.token || this._generateToken();
         this._info.url = new URL(
           `http://localhost:8080/#/?username=user&password=password/`
         );
-
+        
         let baseCondaPath: string = '';
 
         if (this._info.environment.type === IEnvironmentType.CondaRoot) {
           baseCondaPath = getEnvironmentPath(this._info.environment);
         } else if (this._info.environment.type === IEnvironmentType.CondaEnv) {
           baseCondaPath = await this._registry.condaRootPath;
-
-          if (!baseCondaPath) {
-            const choice = dialog.showMessageBoxSync({
-              message: 'Select conda base environment',
-              detail:
-                'Base conda environment not found. Please select a root conda environment to activate the custom environment.',
-              type: 'error',
-              buttons: ['OK', 'Cancel'],
-              defaultId: 0,
-              cancelId: 1
-            });
-            if (choice == 1) {
-              reject('Failed to activate conda environment');
-              return;
-            }
-
-            const filePaths = dialog.showOpenDialogSync({
-              properties: [
-                'openDirectory',
-                'showHiddenFiles',
-                'noResolveAliases'
-              ],
-              buttonLabel: 'Use Conda Root'
-            });
-
-            if (filePaths && filePaths.length > 0) {
-              baseCondaPath = filePaths[0];
-              if (
-                !this._registry.validateCondaBaseEnvironmentAtPath(
-                  baseCondaPath
-                )
-              ) {
-                reject('Invalid base conda environment');
-                return;
-              }
-              this._registry.setCondaRootPath(baseCondaPath);
-            } else {
-              reject('Failed to activate conda environment');
-              return;
-            }
-          }
         }
+
+        //   if (!baseCondaPath) {
+        //     const choice = dialog.showMessageBoxSync({
+        //       message: 'Select conda base environment',
+        //       detail:
+        //         'Base conda environment not found. Please select a root conda environment to activate the custom environment.',
+        //       type: 'error',
+        //       buttons: ['OK', 'Cancel'],
+        //       defaultId: 0,
+        //       cancelId: 1
+        //     });
+        //     if (choice == 1) {
+        //       reject('Failed to activate conda environment');
+        //       return;
+        //     }
+
+        //     const filePaths = dialog.showOpenDialogSync({
+        //       properties: [
+        //         'openDirectory',
+        //         'showHiddenFiles',
+        //         'noResolveAliases'
+        //       ],
+        //       buttonLabel: 'Use Conda Root'
+        //     });
+
+        //     if (filePaths && filePaths.length > 0) {
+        //       baseCondaPath = filePaths[0];
+        //       if (
+        //         !this._registry.validateCondaBaseEnvironmentAtPath(
+        //           baseCondaPath
+        //         )
+        //       ) {
+        //         reject('Invalid base conda environment');
+        //         return;
+        //       }
+        //       this._registry.setCondaRootPath(baseCondaPath);
+        //     } else {
+        //       reject('Failed to activate conda environment');
+        //       return;
+        //     }
+        //   }
+        // }
 
         const launchScriptPath = createLaunchScript(
           this._info,
@@ -294,6 +305,7 @@ export class JupyterServer {
             fs.unlinkSync(launchScriptPath);
             resolve(this._info);
           } else {
+            console.debug("Server didn't start in time")
             this._serverStartFailed();
             reject(new Error('Failed to launch Jupyter Server'));
           }
@@ -513,11 +525,11 @@ export namespace JupyterServer {
     url: URL;
     port: number;
     token: string;
-    environment: IPythonEnvironment;
+    environment?: IPythonEnvironment;
     workingDirectory: string;
-    serverArgs: string;
-    overrideDefaultServerArgs: boolean;
-    serverEnvVars: KeyValueMap;
+    serverArgs?: string;
+    overrideDefaultServerArgs?: boolean;
+    serverEnvVars?: KeyValueMap;
     version?: string;
     pageConfig?: any;
   }
@@ -619,21 +631,27 @@ export class JupyterServerFactory implements IServerFactory, IDisposable {
     opts?: JupyterServer.IOptions
   ): Promise<JupyterServerFactory.IFactoryItem> {
     let item: JupyterServerFactory.IFactoryItem;
-    let env: IPythonEnvironment;
+    let env: IPythonEnvironment = {
+      name: 'python',
+      path: 'C:\\',
+      type: IEnvironmentType.Path,
+      versions: {},
+      defaultKernel: 'python3'
+    };
 
-    if (!opts?.environment) {
-      env = await this._registry.getDefaultEnvironment();
-    } else {
-      env = opts?.environment;
-    }
-
+    // if (!opts?.environment) {
+    //   env = await this._registry.getDefaultEnvironment();
+    // } else {
+      // env = opts?.environment;
+    // }
+    console.debug('~ createFreeServer', opts);
     opts = { ...opts, ...{ environment: env } };
     item = this._createServer(opts);
     item.server.start().catch(error => {
-      console.error('Failed to start server', error);
+      console.error('Failed to start server ~~', error);
       this._removeFailedServer(item.factoryId);
     });
-
+    console.debug('~ createdFreeServer ~ ', item);
     return item;
   }
 
@@ -649,24 +667,31 @@ export class JupyterServerFactory implements IServerFactory, IDisposable {
     opts?: JupyterServer.IOptions
   ): Promise<JupyterServerFactory.IFactoryItem> {
     let item: JupyterServerFactory.IFactoryItem;
-    let env: IPythonEnvironment;
+    let env: IPythonEnvironment = {
+      name: 'python',
+      path: 'C:\\',
+      type: IEnvironmentType.Path,
+      versions: {},
+      defaultKernel: 'python3'
+    };
 
-    if (!opts?.environment) {
-      env = await this._registry.getDefaultEnvironment();
-    } else {
-      env = opts?.environment;
-    }
-
+    // if (!opts?.environment) {
+    //   env = await this._registry.getDefaultEnvironment();
+    // } else {
+      // env = opts?.environment;
+    // }
+    console.log('~ createServer', opts?.environment)
     opts = { ...opts, ...{ environment: env } };
 
     item = (await this._findUnusedServer(opts)) || this._createServer(opts);
     item.used = true;
 
     item.server.start().catch(error => {
-      console.error('Failed to start server', error);
+      console.error('~ Failed to start server', error);
       this._removeFailedServer(item.factoryId);
     });
 
+    console.debug('~ createServer ~ ', item);
     return item;
   }
 
@@ -753,7 +778,7 @@ export class JupyterServerFactory implements IServerFactory, IDisposable {
     const workingDir =
       opts?.workingDirectory || userSettings.resolvedWorkingDirectory;
     const env =
-      opts?.environment || (await this._registry.getDefaultEnvironment());
+      opts?.environment;
 
     let result = ArrayExt.findFirstValue(
       this._servers,
@@ -778,7 +803,7 @@ export class JupyterServerFactory implements IServerFactory, IDisposable {
       opts?.workingDirectory || userSettings.resolvedWorkingDirectory;
 
     const env =
-      opts?.environment || (await this._registry.getDefaultEnvironment());
+      opts?.environment;
 
     this._servers.forEach(server => {
       if (

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -31,6 +31,7 @@ import {
 import { IServerFactory, JupyterServer, JupyterServerFactory } from '../server';
 import {
   IDisposable,
+  IEnvironmentType,
   IPythonEnvironment,
   IRect,
   IVersionContainer
@@ -154,6 +155,17 @@ export class SessionWindow implements IDisposable {
         pythonPath
       );
     }
+    else {
+      let option: IPythonEnvironment = {
+        name: 'python',
+        path: 'C:\\',
+        type: IEnvironmentType.Path,
+        versions: {},
+        defaultKernel: 'python3'
+      };
+      serverOptions.environment = option;
+    }
+    console.debug('serverOptions ', serverOptions); 
 
     const server = await this.serverFactory.createServer(serverOptions);
     this._server = server;
@@ -1013,8 +1025,8 @@ export class SessionWindow implements IDisposable {
 
   private async _createEnvSelectPopup() {
     const envs = await this.registry.getEnvironmentList(false);
-    const defaultEnv = await this._registry.getDefaultEnvironment();
-    const defaultPythonPath = defaultEnv ? defaultEnv.path : '';
+    // const defaultEnv = await this._registry.getDefaultEnvironment();
+    const defaultPythonPath = '';
 
     this._envSelectPopup = new PythonEnvironmentSelectPopup({
       isDarkTheme: this._isDarkTheme,
@@ -1032,12 +1044,12 @@ export class SessionWindow implements IDisposable {
     }
 
     let currentPythonPath = this._wsSettings.getValue(SettingType.pythonPath);
-    if (!currentPythonPath) {
-      const defaultEnv = await this.registry.getDefaultEnvironment();
-      if (defaultEnv) {
-        currentPythonPath = defaultEnv.path;
-      }
-    }
+    // if (!currentPythonPath) {
+    //   const defaultEnv = await this.registry.getDefaultEnvironment();
+    //   if (defaultEnv) {
+    //     currentPythonPath = defaultEnv.path;
+    //   }
+    // }
 
     this._envSelectPopup.setCurrentPythonPath(currentPythonPath);
 

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { appData } from '../config/appdata';
 import { IRegistry } from '../registry';
-import { EventTypeMain, EventTypeRenderer } from '../eventtypes';
+import { EventTypeRenderer } from '../eventtypes';
 
 const maxRecentItems = 5;
 
@@ -20,7 +20,7 @@ interface IRecentSessionListItem {
 
 export class WelcomeView {
   constructor(options: WelcomeView.IOptions) {
-    this._registry = options.registry;
+    // this._registry = options.registry;
     this._isDarkTheme = options.isDarkTheme;
     this._view = new BrowserView({
       webPreferences: {
@@ -48,7 +48,6 @@ export class WelcomeView {
     const openIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M88.7 223.8L0 375.8V96C0 60.7 28.7 32 64 32H181.5c17 0 33.3 6.7 45.3 18.7l26.5 26.5c12 12 28.3 18.7 45.3 18.7H416c35.3 0 64 28.7 64 64v32H144c-22.8 0-43.8 12.1-55.3 31.8zm27.6 16.1C122.1 230 132.6 224 144 224H544c11.5 0 22 6.1 27.7 16.1s5.7 22.2-.1 32.1l-112 192C453.9 474 443.4 480 432 480H32c-11.5 0-22-6.1-27.7-16.1s-5.7-22.2 .1-32.1l112-192z"/></svg>`;
     const serverIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M64 32C28.7 32 0 60.7 0 96v64c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zM344 152c-13.3 0-24-10.7-24-24s10.7-24 24-24s24 10.7 24 24s-10.7 24-24 24zm96-24c0 13.3-10.7 24-24 24s-24-10.7-24-24s10.7-24 24-24s24 10.7 24 24zM64 288c-35.3 0-64 28.7-64 64v64c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V352c0-35.3-28.7-64-64-64H64zM344 408c-13.3 0-24-10.7-24-24s10.7-24 24-24s24 10.7 24 24s-10.7 24-24 24zm104-24c0 13.3-10.7 24-24 24s-24-10.7-24-24s10.7-24 24-24s24 10.7 24 24z"/></svg>`;
     // const externalLinkIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V32c0-17.7-14.3-32-32-32H352zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/></svg>`;
-    // const dockerIcon  = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M349.9 236.3h-66.1v-59.4h66.1v59.4zm0-204.3h-66.1v60.7h66.1V32zm78.2 144.8H362v59.4h66.1v-59.4zm-156.3-72.1h-66.1v60.1h66.1v-60.1zm78.1 0h-66.1v60.1h66.1v-60.1zm276.8 100c-14.4-9.7-47.6-13.2-73.1-8.4-3.3-24-16.7-44.9-41.1-63.7l-14-9.3-9.3 14c-18.4 27.8-23.4 73.6-3.7 103.8-8.7 4.7-25.8 11.1-48.4 10.7H2.4c-8.7 50.8 5.8 116.8 44 162.1 37.1 43.9 92.7 66.2 165.4 66.2 157.4 0 273.9-72.5 328.4-204.2 21.4.4 67.6.1 91.3-45.2 1.5-2.5 6.6-13.2 8.5-17.1l-13.3-8.9zm-511.1-27.9h-66v59.4h66.1v-59.4zm78.1 0h-66.1v59.4h66.1v-59.4zm78.1 0h-66.1v59.4h66.1v-59.4zm-78.1-72.1h-66.1v60.1h66.1v-60.1z"/></svg>`;
     
     // const showNewsFeed = userSettings.getValue(SettingType.showNewsFeed);
     // if (showNewsFeed) {
@@ -512,26 +511,8 @@ export class WelcomeView {
             notificationPanel.style.display = "none";
           }
 
-          function disableLocalServerActions() {
-            const serverActionIds = ["new-notebook-link", "new-session-link", "open-file-or-folder-link", "open-file-link", "open-folder-link"];
-            serverActionIds.forEach(id => {
-              const link = document.getElementById(id);
-              if (link) {
-                link.classList.add("disabled");
-              }
-            });
-
-            document.querySelectorAll('div.recent-item-local').forEach(link => {
-              link.classList.add("disabled");
-            });
-          }
-
           window.electronAPI.onSetNotificationMessage((message, closable) => {
             showNotificationPanel(message, closable);
-          });
-
-          window.electronAPI.onDisableLocalServerActions(() => {
-            disableLocalServerActions();
           });
 
           window.electronAPI.onInstallBundledPythonEnvStatus((status, detail) => {
@@ -577,27 +558,27 @@ export class WelcomeView {
 
     this.updateRecentSessionList(true);
 
-    this._registry.getDefaultEnvironment().catch(() => {
-      this.disableLocalServerActions();
-      this.showNotification(
-        `
-        <div>
-          <svg style="width: 20px; height: 20px; fill: orange; margin-right: 6px;">
-            <use href="#triangle-exclamation" />
-          </svg>
-        </div>
-        Python environment not found. <a href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Install using the bundled installer</a> or <a href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.ShowServerSettings}')">Change the default Python environment</a>
-        `,
-        true
-      );
-    });
+    // this._registry.getDefaultEnvironment().catch(() => {
+    //   this.disableLocalServerActions();
+    //   this.showNotification(
+    //     `
+    //     <div>
+    //       <svg style="width: 20px; height: 20px; fill: orange; margin-right: 6px;">
+    //         <use href="#triangle-exclamation" />
+    //       </svg>
+    //     </div>
+    //     Python environment not found. <a href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Install using the bundled installer</a> or <a href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.ShowServerSettings}')">Change the default Python environment</a>
+    //     `,
+    //     true
+    //   );
+    // });
   }
 
-  disableLocalServerActions() {
-    this._viewReady.then(() => {
-      this._view.webContents.send(EventTypeRenderer.DisableLocalServerActions);
-    });
-  }
+  // disableLocalServerActions() {
+  //   this._viewReady.then(() => {
+  //     this._view.webContents.send(EventTypeRenderer.DisableLocalServerActions);
+  //   });
+  // }
 
   showNotification(message: string, closable: boolean) {
     this._viewReady.then(() => {
@@ -665,7 +646,7 @@ export class WelcomeView {
   private _isDarkTheme: boolean;
   private _view: BrowserView;
   private _viewReady: Promise<void>;
-  private _registry: IRegistry;
+  // private _registry: IRegistry;
   private _pageSource: string;
 }
 


### PR DESCRIPTION
Fix #1 

Initialize IPythonEnvironment with defaults to resolve Promise for `this._startServer` in `server.ts`

```IPythonEnvironment = {
      name: 'python',
      path: 'C:\\',
      type: IEnvironmentType.Path,
      versions: {},
      defaultKernel: 'python3'
    }```